### PR TITLE
Add minecraft discord bot module

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -3,7 +3,7 @@ name: Test Plan
 on:
   push:
     branches:
-      - 'feature/**'
+      - '**'
 env:
   AWS_REGION: "us-east-1"
 permissions:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -3,7 +3,7 @@ name: Test Plan
 on:
   push:
     branches:
-      - '*'
+      - 'feature/**'
 env:
   AWS_REGION: "us-east-1"
 permissions:

--- a/minecraft_discord_bot.tf
+++ b/minecraft_discord_bot.tf
@@ -1,9 +1,9 @@
 module "minecraft_discord_bot" {
   source = "./modules/minecraft-discord-bot"
-  config_bucket_key_name = "config.json"
-  config_bucket_name = "minecraft-discord-bot"
+  config_bucket_key_name = "discord-bot-config.json"
+  config_bucket_name = "dev-minecraft-snapshots-298urhg"
   ecs_subnet_id = aws_subnet.private_subnet.id
-  ecs_task_image = "622452799301.dkr.ecr.us-west-2.amazonaws.com/minecraft-discord-bot:latest"
+  ecs_task_image = "553590173470.dkr.ecr.us-east-1.amazonaws.com/minecraft-friends/minecraft-discord-bot:latest"
   env = local.environment
   tags = local.tags
   region = local.region

--- a/minecraft_discord_bot.tf
+++ b/minecraft_discord_bot.tf
@@ -2,7 +2,7 @@ module "minecraft_discord_bot" {
   source = "./modules/minecraft-discord-bot"
   config_bucket_key_name = "config.json"
   config_bucket_name = "minecraft-discord-bot"
-  ecs_subnet_id = aws_subnet.minecraft_server_public_subnet.id
+  ecs_subnet_id = aws_subnet.private_subnet.id
   ecs_task_image = "622452799301.dkr.ecr.us-west-2.amazonaws.com/minecraft-discord-bot:latest"
   env = local.environment
   tags = local.tags

--- a/minecraft_discord_bot.tf
+++ b/minecraft_discord_bot.tf
@@ -7,4 +7,5 @@ module "minecraft_discord_bot" {
   env = local.environment
   tags = local.tags
   region = local.region
+  minecraft_server_ec2_instance_id = aws_instance.minecraft_server.id
 }

--- a/minecraft_discord_bot.tf
+++ b/minecraft_discord_bot.tf
@@ -6,4 +6,5 @@ module "minecraft_discord_bot" {
   ecs_task_image = "622452799301.dkr.ecr.us-west-2.amazonaws.com/minecraft-discord-bot:latest"
   env = local.environment
   tags = local.tags
+  region = local.region
 }

--- a/minecraft_discord_bot.tf
+++ b/minecraft_discord_bot.tf
@@ -1,0 +1,9 @@
+module "minecraft_discord_bot" {
+  source = "./modules/minecraft-discord-bot"
+  config_bucket_key_name = "config.json"
+  config_bucket_name = "minecraft-discord-bot"
+  ecs_subnet_id = aws_subnet.minecraft_server_public_subnet.id
+  ecs_task_image = "622452799301.dkr.ecr.us-west-2.amazonaws.com/minecraft-discord-bot:latest"
+  env = local.environment
+  tags = local.tags
+}

--- a/modules/minecraft-discord-bot/README.md
+++ b/modules/minecraft-discord-bot/README.md
@@ -1,0 +1,7 @@
+# Minecraft Discord Bot
+
+## Requirements
+
+* Bucket with `config.json` file. The iam task role created with this module needs access to the bucket. 
+* ECR repository where the image for https://github.com/minecraft-friends/minecraft-discord-bot is hosted.
+

--- a/modules/minecraft-discord-bot/cloudwatch.tf
+++ b/modules/minecraft-discord-bot/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "minecraft_discord_bot" {
+  name = "${var.env}_minecraft_discord_bot"
+  tags = var.tags
+}

--- a/modules/minecraft-discord-bot/cloudwatch.tf
+++ b/modules/minecraft-discord-bot/cloudwatch.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "minecraft_discord_bot" {
   name = "${var.env}_minecraft_discord_bot"
+  retention_in_days = 7
   tags = var.tags
 }

--- a/modules/minecraft-discord-bot/ecs.tf
+++ b/modules/minecraft-discord-bot/ecs.tf
@@ -37,6 +37,10 @@ resource "aws_ecs_task_definition" "minecraft_discord_bot" {
         {
           name = "BUCKET_KEY_NAME",
           value = var.config_bucket_key_name
+        },
+        {
+          name = "EC2_INSTANCE_ID",
+          value = var.config_bucket_key_name
         }
       ],
       runtime_platform = {

--- a/modules/minecraft-discord-bot/ecs.tf
+++ b/modules/minecraft-discord-bot/ecs.tf
@@ -20,16 +20,16 @@ resource "aws_ecs_task_definition" "minecraft_discord_bot" {
   family = "service"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = 256
-  memory                   = 512
+  cpu                      = var.ecs_task_cpu
+  memory                   = var.ecs_task_memory
   execution_role_arn = aws_iam_role.minecraft_discord_bot_task_role.arn
   task_role_arn = aws_iam_role.minecraft_discord_bot_task_role.arn
   container_definitions = jsonencode([
     {
       name      = "minecraft_discord_bot"
       image     = var.ecs_task_image
-      cpu = 256
-      memory = 512
+      cpu = var.ecs_task_container_cpu
+      memory = var.ecs_task_container_memory
       environment= [
         {
           name = "BUCKET_NAME",
@@ -48,7 +48,7 @@ resource "aws_ecs_task_definition" "minecraft_discord_bot" {
         logDriver = "awslogs",
         options= {
           awslogs-group= aws_cloudwatch_log_group.minecraft_discord_bot.name,
-          "awslogs-region": "us-west-2",
+          "awslogs-region": var.region,
           "awslogs-stream-prefix": "ecs"
         }
       },

--- a/modules/minecraft-discord-bot/ecs.tf
+++ b/modules/minecraft-discord-bot/ecs.tf
@@ -6,7 +6,6 @@ resource "aws_ecs_service" "minecraft_discord_bot" {
   desired_count   = 1
   network_configuration {
     subnets = [var.ecs_subnet_id]
-    assign_public_ip = true
   }
   tags = var.tags
 }

--- a/modules/minecraft-discord-bot/ecs.tf
+++ b/modules/minecraft-discord-bot/ecs.tf
@@ -1,0 +1,60 @@
+resource "aws_ecs_service" "minecraft_discord_bot" {
+  name            = "${var.env}_minecraft_discord_bot"
+  cluster         = aws_ecs_cluster.minecraft_discord_bot.id
+  task_definition = aws_ecs_task_definition.minecraft_discord_bot.arn
+  launch_type = "FARGATE"
+  desired_count   = 1
+  network_configuration {
+    subnets = [var.ecs_subnet_id]
+    assign_public_ip = true
+  }
+  tags = var.tags
+}
+
+resource "aws_ecs_cluster" "minecraft_discord_bot" {
+  name = "${var.env}_minecraft_discord_bot"
+  tags = var.tags
+}
+
+resource "aws_ecs_task_definition" "minecraft_discord_bot" {
+  family = "service"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn = aws_iam_role.minecraft_discord_bot_task_role.arn
+  task_role_arn = aws_iam_role.minecraft_discord_bot_task_role.arn
+  container_definitions = jsonencode([
+    {
+      name      = "minecraft_discord_bot"
+      image     = var.ecs_task_image
+      cpu = 256
+      memory = 512
+      environment= [
+        {
+          name = "BUCKET_NAME",
+          value = var.config_bucket_name
+        },
+        {
+          name = "BUCKET_KEY_NAME",
+          value = var.config_bucket_key_name
+        }
+      ],
+      runtime_platform = {
+        operating_system_family = "LINUX"
+        cpu_architecture        = "ARM64"
+      },
+      logConfiguration = {
+        logDriver = "awslogs",
+        options= {
+          awslogs-group= aws_cloudwatch_log_group.minecraft_discord_bot.name,
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      tags = var.tags
+    }
+  ])
+  tags = var.tags
+}
+

--- a/modules/minecraft-discord-bot/iam.tf
+++ b/modules/minecraft-discord-bot/iam.tf
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy" "minecraft_discord_bot_logs_policy" {
         ],
         Effect = "Allow",
         Resource = [
-          "arn:aws:logs:*:*:*"
+          aws_cloudwatch_log_group.minecraft_discord_bot.arn
         ]
       },
     ]

--- a/modules/minecraft-discord-bot/iam.tf
+++ b/modules/minecraft-discord-bot/iam.tf
@@ -33,13 +33,17 @@ resource "aws_iam_role_policy" "minecraft_discord_bot_s3_access" {
   name   = "${var.env}_minecraft_discord_bot_s3_access"
   role   = aws_iam_role.minecraft_discord_bot_task_role.name
   policy = jsonencode({
-      Action = [
-      "s3:GetObject",
-    ],
-      Effect = "Allow",
-      Resource = [
-        aws_cloudwatch_log_group.minecraft_discord_bot.arn
-      ]
+    Statement = [
+      {
+        Action = [
+          "s3:GetObject",
+        ],
+        Effect = "Allow",
+        Resource = [
+          "arn:aws:s3:::${var.config_bucket_name}"
+        ]
+      },
+    ]
   })
 }
 

--- a/modules/minecraft-discord-bot/iam.tf
+++ b/modules/minecraft-discord-bot/iam.tf
@@ -29,6 +29,20 @@ resource "aws_iam_policy_attachment" "minecraft_discord_bot_task_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy" "minecraft_discord_bot_s3_access" {
+  name   = "${var.env}_minecraft_discord_bot_s3_access"
+  role   = aws_iam_role.minecraft_discord_bot_task_role.name
+  policy = jsonencode({
+      Action = [
+      "s3:GetObject",
+    ],
+      Effect = "Allow",
+      Resource = [
+        aws_cloudwatch_log_group.minecraft_discord_bot.arn
+      ]
+  })
+}
+
 resource "aws_iam_role_policy" "minecraft_discord_bot_logs_policy" {
   name   = "${var.env}_minecraft_discord_bot_lambda_logs"
   role   = aws_iam_role.minecraft_discord_bot_task_role.name

--- a/modules/minecraft-discord-bot/iam.tf
+++ b/modules/minecraft-discord-bot/iam.tf
@@ -1,0 +1,52 @@
+data "aws_caller_identity" "current" {}
+locals {
+  name = "${var.env}-minecraft-discord-bot"
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_iam_role" "minecraft_discord_bot_task_role" {
+  name = local.name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = "AssumeRole"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_policy_attachment" "minecraft_discord_bot_task_policy" {
+  name   = "${var.env}_minecraft_discord_bot_lambda_logs"
+  roles   = [aws_iam_role.minecraft_discord_bot_task_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "minecraft_discord_bot_logs_policy" {
+  name   = "${var.env}_minecraft_discord_bot_lambda_logs"
+  role   = aws_iam_role.minecraft_discord_bot_task_role.name
+  policy = jsonencode({
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams",
+          "logs:ListTagsLogGroup",
+        ],
+        Effect = "Allow",
+        Resource = [
+          "arn:aws:logs:*:*:*"
+        ]
+      },
+    ]
+  })
+}

--- a/modules/minecraft-discord-bot/variables.tf
+++ b/modules/minecraft-discord-bot/variables.tf
@@ -1,0 +1,30 @@
+variable "env" {
+  type = string
+  description = "The name of the env"
+}
+
+variable "tags" {
+  default     = {}
+  description = "Tags to add to all resources"
+  type        = map(string)
+}
+
+variable "ecs_subnet_id" {
+  type = string
+  description = "the subnet used by the ecs service"
+}
+
+variable "config_bucket_name" {
+  type = string
+  description = "The name of the bucket used for the discord bot config"
+}
+
+variable "config_bucket_key_name" {
+  type = string
+  description = "The name of the bucket key used for the discord bot config"
+}
+
+variable "ecs_task_image" {
+  type = string
+  description = "The image used by the ecs task"
+}

--- a/modules/minecraft-discord-bot/variables.tf
+++ b/modules/minecraft-discord-bot/variables.tf
@@ -29,6 +29,11 @@ variable "config_bucket_key_name" {
   description = "The name of the bucket key used for the discord bot config"
 }
 
+variable "minecraft_server_ec2_instance_id" {
+  type = string
+  description = "The instance id of the EC2 instance"
+}
+
 variable "ecs_task_image" {
   type = string
   description = "The image used by the ecs task"

--- a/modules/minecraft-discord-bot/variables.tf
+++ b/modules/minecraft-discord-bot/variables.tf
@@ -3,6 +3,11 @@ variable "env" {
   description = "The name of the env"
 }
 
+variable "region" {
+  type = string
+  description = "The aws region to use"
+}
+
 variable "tags" {
   default     = {}
   description = "Tags to add to all resources"
@@ -27,4 +32,28 @@ variable "config_bucket_key_name" {
 variable "ecs_task_image" {
   type = string
   description = "The image used by the ecs task"
+}
+
+variable "ecs_task_cpu" {
+  type = number
+  description = "The cpu used by the ecs task"
+  default = 256
+}
+
+variable "ecs_task_memory" {
+  type = number
+  description = "The cpu used by the ecs task"
+  default = 512
+}
+
+variable "ecs_task_container_cpu" {
+  type = number
+  description = "The cpu used by the ecs task"
+  default = 256
+}
+
+variable "ecs_task_container_memory" {
+  type = number
+  description = "The cpu used by the ecs task"
+  default = 512
 }

--- a/network.tf
+++ b/network.tf
@@ -3,6 +3,8 @@ resource "aws_vpc" "minecraft_server_vpc" {
   tags = local.tags
 }
 
+// public
+
 resource "aws_subnet" "minecraft_server_public_subnet" {
   vpc_id = aws_vpc.minecraft_server_vpc.id
   cidr_block = "10.0.1.0/24"
@@ -92,4 +94,42 @@ resource "aws_security_group" "minecraft_server_allow_ssh" {
   ]
 
   tags = local.tags
+}
+
+resource "aws_eip" "nat_eip" {
+  vpc        = true
+  depends_on = [aws_internet_gateway.minecraft_server_igw]
+}
+
+resource "aws_nat_gateway" "nat_gateway" {
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id     = aws_subnet.minecraft_server_public_subnet.id
+  depends_on    = [aws_internet_gateway.minecraft_server_igw]
+  tags = local.tags
+}
+
+// private
+
+resource "aws_subnet" "private_subnet" {
+  vpc_id                  = aws_vpc.minecraft_server_vpc.id
+  cidr_block = "10.0.2.0/24"
+  availability_zone = format("%s%s", local.region, "a")
+  map_public_ip_on_launch = false
+  tags = local.tags
+}
+
+resource "aws_route_table" "private_route_table" {
+  vpc_id = aws_vpc.minecraft_server_vpc.id
+  tags = local.tags
+}
+
+resource "aws_route_table_association" "private_route_table" {
+  subnet_id = aws_subnet.private_subnet.id
+  route_table_id = aws_route_table.private_route_table.id
+}
+
+resource "aws_route" "private_nat_gateway" {
+  route_table_id         = aws_route_table.private_route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat_gateway.id
 }


### PR DESCRIPTION
Add a terraform module for the minecraft discord bot ECS resources. 

Image for the ECS task is dependent on https://github.com/minecraft-friends/minecraft-discord-bot/pull/1. 